### PR TITLE
Add citation file to enable GitHub's enhanced support for citations

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,10 +6,10 @@ title: >-
   UVaFTLE: Lagrangian finite time Lyapunov exponent
   extraction for fluid dynamic applications
 message: >-
-  f you write a scientific paper describing research that
+  If you write a scientific paper describing research that
   makes substantive use of UVaFTLE , we would appreciate
   that you cite the following paper:
-type: software
+type: article
 authors:
   - given-names: Rocío
     family-names: Carratalá-Sáez
@@ -23,13 +23,11 @@ authors:
   - given-names: Sergio
     family-names: López-Huguet
     orcid: 'https://orcid.org/0000-0002-6523-6108'
-  - given-names: Diego
-    name-particle: R.
+  - given-names: Diego R.
     family-names: Llanos
     orcid: 'https://orcid.org/0000-0001-6240-9109'
-identifiers:
-  - type: doi
-    value: 10.1007/s11227-022-05017-x
+doi: '10.1007/s11227-022-05017-x'
+journal: 'The Journal of Supercomputing'
 repository-code: 'https://github.com/uva-trasgo/UVaFTLE'
 abstract: >-
   The determination of Lagrangian Coherent Structures (LCS)
@@ -59,3 +57,4 @@ keywords:
   - Multithreading
   - Multi-GPU
 date-released: '2023-01-19'
+url: 'https://link.springer.com/article/10.1007/s11227-022-05017-x'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,56 +1,80 @@
 cff-version: 1.2.0
-title: >-
-  UVaFTLE: Lagrangian finite time Lyapunov exponent
-  extraction for fluid dynamic applications
 message: >-
   If you write a scientific paper describing research that
   makes substantive use of UVaFTLE , we would appreciate
   that you cite the following paper:
-type: article
 authors:
-  - given-names: Rocío
-    family-names: Carratalá-Sáez
+  - given-names: "Rocío"
+    family-names: "Carratalá-Sáez"
     orcid: 'https://orcid.org/0000-0001-8409-2421'
-  - given-names: Yuri
-    family-names: Torres
+  - given-names: "Yuri"
+    family-names: "Torres"
     orcid: 'https://orcid.org/0000-0002-3037-3567'
-  - given-names: José
-    family-names: Sierra-Pallares
+  - given-names: "José"
+    family-names: "Sierra-Pallares"
     orcid: 'https://orcid.org/0000-0003-1565-9337'
-  - given-names: Sergio
-    family-names: López-Huguet
+  - given-names: "Sergio"
+    family-names: "López-Huguet"
     orcid: 'https://orcid.org/0000-0002-6523-6108'
-  - given-names: Diego R.
-    family-names: Llanos
+  - given-names: "Diego R."
+    family-names: "Llanos"
     orcid: 'https://orcid.org/0000-0001-6240-9109'
-doi: '10.1007/s11227-022-05017-x'
-journal: 'The Journal of Supercomputing'
-abstract: >-
-  The determination of Lagrangian Coherent Structures (LCS)
-  is becoming very important in several disciplines,
-  including cardiovascular engineering, aerodynamics, and
-  geophysical fluid dynamics. From the computational point
-  of view, the extraction of LCS consists of two main steps:
-  The flowmap computation and the resolution of Finite Time
-  Lyapunov Exponents (FTLE). In this work, we focus on the
-  design, implementation, and parallelization of the FTLE
-  resolution. We offer an in-depth analysis of this
-  procedure, as well as an open source C implementation
-  (UVaFTLE) parallelized using OpenMP directives to attain a
-  fair parallel efficiency in shared-memory environments. We
-  have also implemented CUDA kernels that allow UVaFTLE to
-  leverage as many NVIDIA GPU devices as desired in order to
-  reach the best parallel efficiency. For the sake of
-  reproducibility and in order to contribute to open
-  science, our code is publicly available through GitHub.
-  Moreover, we also provide Docker containers to ease its
-  usage.
-keywords:
-  - Finite time Lyapunov exponent
-  - Lagrarian coherent structures
-  - OpenMP
-  - GPU
-  - Multithreading
-  - Multi-GPU
+title: >-
+  UVaFTLE: Lagrangian finite time Lyapunov exponent
+  extraction for fluid dynamic applications
 date-released: '2023-01-19'
-url: 'https://link.springer.com/article/10.1007/s11227-022-05017-x'
+url: 'https://github.com/uva-trasgo/UVaFTLE'
+preferred-citation:
+    type: article
+    authors:
+      - given-names: "Rocío"
+        family-names: "Carratalá-Sáez"
+        orcid: 'https://orcid.org/0000-0001-8409-2421'
+      - given-names: "Yuri"
+        family-names: "Torres"
+        orcid: 'https://orcid.org/0000-0002-3037-3567'
+      - given-names: "José"
+        family-names: "Sierra-Pallares"
+        orcid: 'https://orcid.org/0000-0003-1565-9337'
+      - given-names: "Sergio"
+        family-names: "López-Huguet""
+        orcid: 'https://orcid.org/0000-0002-6523-6108'
+      - given-names: "Diego R."
+        family-names: "Llanos"
+        orcid: 'https://orcid.org/0000-0001-6240-9109'
+    title: >-
+      UVaFTLE: Lagrangian finite time Lyapunov exponent
+      extraction for fluid dynamic applications
+    doi: '10.1007/s11227-022-05017-x'
+    journal: 'The Journal of Supercomputing'
+    month: 1
+    year: 2023
+    issn: "1573-0484"
+    abstract: >-
+      The determination of Lagrangian Coherent Structures (LCS)
+      is becoming very important in several disciplines,
+      including cardiovascular engineering, aerodynamics, and
+      geophysical fluid dynamics. From the computational point
+      of view, the extraction of LCS consists of two main steps:
+      The flowmap computation and the resolution of Finite Time
+      Lyapunov Exponents (FTLE). In this work, we focus on the
+      design, implementation, and parallelization of the FTLE
+      resolution. We offer an in-depth analysis of this
+      procedure, as well as an open source C implementation
+      (UVaFTLE) parallelized using OpenMP directives to attain a
+      fair parallel efficiency in shared-memory environments. We
+      have also implemented CUDA kernels that allow UVaFTLE to
+      leverage as many NVIDIA GPU devices as desired in order to
+      reach the best parallel efficiency. For the sake of
+      reproducibility and in order to contribute to open
+      science, our code is publicly available through GitHub.
+      Moreover, we also provide Docker containers to ease its
+      usage.
+    keywords:
+      - Finite time Lyapunov exponent
+      - Lagrarian coherent structures
+      - OpenMP
+      - GPU
+      - Multithreading
+      - Multi-GPU
+    

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,80 +1,45 @@
 cff-version: 1.2.0
-message: >-
-  If you write a scientific paper describing research that
-  makes substantive use of UVaFTLE , we would appreciate
-  that you cite the following paper:
+message: "If you write a scientific paper describing research that makes substantive use of UVaFTLE , we would appreciate that you cite the following paper:"
 authors:
-  - given-names: "Rocío"
-    family-names: "Carratalá-Sáez"
-    orcid: 'https://orcid.org/0000-0001-8409-2421'
-  - given-names: "Yuri"
-    family-names: "Torres"
-    orcid: 'https://orcid.org/0000-0002-3037-3567'
-  - given-names: "José"
-    family-names: "Sierra-Pallares"
-    orcid: 'https://orcid.org/0000-0003-1565-9337'
-  - given-names: "Sergio"
-    family-names: "López-Huguet"
-    orcid: 'https://orcid.org/0000-0002-6523-6108'
-  - given-names: "Diego R."
-    family-names: "Llanos"
-    orcid: 'https://orcid.org/0000-0001-6240-9109'
-title: >-
-  UVaFTLE: Lagrangian finite time Lyapunov exponent
-  extraction for fluid dynamic applications
-date-released: '2023-01-19'
+- given-names: 'Rocío'
+  family-names: 'Carratalá-Sáez'
+  orcid: 'https://orcid.org/0000-0001-8409-2421'
+- given-names: 'Yuri'
+  family-names: 'Torres'
+  orcid: 'https://orcid.org/0000-0002-3037-3567'
+- given-names: 'José'
+  family-names: 'Sierra-Pallares'
+  orcid: 'https://orcid.org/0000-0003-1565-9337'
+- given-names: 'Sergio'
+  family-names: 'López-Huguet'
+  orcid: 'https://orcid.org/0000-0002-6523-6108'
+- given-names: 'Diego R.'
+  family-names: 'Llanos'
+  orcid: 'https://orcid.org/0000-0001-6240-9109'
+title: "UVaFTLE: Lagrangian finite time Lyapunov exponent extraction for fluid dynamic applications"
+date-released: 2017-12-18
 url: 'https://github.com/uva-trasgo/UVaFTLE'
 preferred-citation:
-    type: article
-    authors:
-      - given-names: "Rocío"
-        family-names: "Carratalá-Sáez"
-        orcid: 'https://orcid.org/0000-0001-8409-2421'
-      - given-names: "Yuri"
-        family-names: "Torres"
-        orcid: 'https://orcid.org/0000-0002-3037-3567'
-      - given-names: "José"
-        family-names: "Sierra-Pallares"
-        orcid: 'https://orcid.org/0000-0003-1565-9337'
-      - given-names: "Sergio"
-        family-names: "López-Huguet""
-        orcid: 'https://orcid.org/0000-0002-6523-6108'
-      - given-names: "Diego R."
-        family-names: "Llanos"
-        orcid: 'https://orcid.org/0000-0001-6240-9109'
-    title: >-
-      UVaFTLE: Lagrangian finite time Lyapunov exponent
-      extraction for fluid dynamic applications
-    doi: '10.1007/s11227-022-05017-x'
-    journal: 'The Journal of Supercomputing'
-    month: 1
-    year: 2023
-    issn: "1573-0484"
-    abstract: >-
-      The determination of Lagrangian Coherent Structures (LCS)
-      is becoming very important in several disciplines,
-      including cardiovascular engineering, aerodynamics, and
-      geophysical fluid dynamics. From the computational point
-      of view, the extraction of LCS consists of two main steps:
-      The flowmap computation and the resolution of Finite Time
-      Lyapunov Exponents (FTLE). In this work, we focus on the
-      design, implementation, and parallelization of the FTLE
-      resolution. We offer an in-depth analysis of this
-      procedure, as well as an open source C implementation
-      (UVaFTLE) parallelized using OpenMP directives to attain a
-      fair parallel efficiency in shared-memory environments. We
-      have also implemented CUDA kernels that allow UVaFTLE to
-      leverage as many NVIDIA GPU devices as desired in order to
-      reach the best parallel efficiency. For the sake of
-      reproducibility and in order to contribute to open
-      science, our code is publicly available through GitHub.
-      Moreover, we also provide Docker containers to ease its
-      usage.
-    keywords:
-      - Finite time Lyapunov exponent
-      - Lagrarian coherent structures
-      - OpenMP
-      - GPU
-      - Multithreading
-      - Multi-GPU
-    
+  type: article
+  authors:
+  - given-names: 'Rocío'
+    family-names: 'Carratalá-Sáez'
+    orcid: 'https://orcid.org/0000-0001-8409-2421'
+  - given-names: 'Yuri'
+    family-names: 'Torres'
+    orcid: 'https://orcid.org/0000-0002-3037-3567'
+  - given-names: 'José'
+    family-names: 'Sierra-Pallares'
+    orcid: 'https://orcid.org/0000-0003-1565-9337'
+  - given-names: 'Sergio'
+    family-names: 'López-Huguet'
+    orcid: 'https://orcid.org/0000-0002-6523-6108'
+  - given-names: 'Diego R.'
+    family-names: 'Llanos'
+    orcid: 'https://orcid.org/0000-0001-6240-9109'
+  doi: '10.1007/s11227-022-05017-x'
+  journal: "The Journal of Supercomputing"
+  month: 1
+  title: "UVaFTLE: Lagrangian finite time Lyapunov exponent extraction for fluid dynamic applications"
+  year: 2023
+  issn: "1573-0484"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,61 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: >-
+  UVaFTLE: Lagrangian finite time Lyapunov exponent
+  extraction for fluid dynamic applications
+message: >-
+  f you write a scientific paper describing research that
+  makes substantive use of UVaFTLE , we would appreciate
+  that you cite the following paper:
+type: software
+authors:
+  - given-names: Rocío
+    family-names: Carratalá-Sáez
+    orcid: 'https://orcid.org/0000-0001-8409-2421'
+  - given-names: Yuri
+    family-names: Torres
+    orcid: 'https://orcid.org/0000-0002-3037-3567'
+  - given-names: José
+    family-names: Sierra-Pallares
+    orcid: 'https://orcid.org/0000-0003-1565-9337'
+  - given-names: Sergio
+    family-names: López-Huguet
+    orcid: 'https://orcid.org/0000-0002-6523-6108'
+  - given-names: Diego
+    name-particle: R.
+    family-names: Llanos
+    orcid: 'https://orcid.org/0000-0001-6240-9109'
+identifiers:
+  - type: doi
+    value: 10.1007/s11227-022-05017-x
+repository-code: 'https://github.com/uva-trasgo/UVaFTLE'
+abstract: >-
+  The determination of Lagrangian Coherent Structures (LCS)
+  is becoming very important in several disciplines,
+  including cardiovascular engineering, aerodynamics, and
+  geophysical fluid dynamics. From the computational point
+  of view, the extraction of LCS consists of two main steps:
+  The flowmap computation and the resolution of Finite Time
+  Lyapunov Exponents (FTLE). In this work, we focus on the
+  design, implementation, and parallelization of the FTLE
+  resolution. We offer an in-depth analysis of this
+  procedure, as well as an open source C implementation
+  (UVaFTLE) parallelized using OpenMP directives to attain a
+  fair parallel efficiency in shared-memory environments. We
+  have also implemented CUDA kernels that allow UVaFTLE to
+  leverage as many NVIDIA GPU devices as desired in order to
+  reach the best parallel efficiency. For the sake of
+  reproducibility and in order to contribute to open
+  science, our code is publicly available through GitHub.
+  Moreover, we also provide Docker containers to ease its
+  usage.
+keywords:
+  - Finite time Lyapunov exponent
+  - Lagrarian coherent structures
+  - OpenMP
+  - GPU
+  - Multithreading
+  - Multi-GPU
+date-released: '2023-01-19'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,3 @@
-# This CITATION.cff file was generated with cffinit.
-# Visit https://bit.ly/cffinit to generate yours today!
-
 cff-version: 1.2.0
 title: >-
   UVaFTLE: Lagrangian finite time Lyapunov exponent
@@ -28,7 +25,6 @@ authors:
     orcid: 'https://orcid.org/0000-0001-6240-9109'
 doi: '10.1007/s11227-022-05017-x'
 journal: 'The Journal of Supercomputing'
-repository-code: 'https://github.com/uva-trasgo/UVaFTLE'
 abstract: >-
   The determination of Lagrangian Coherent Structures (LCS)
   is becoming very important in several disciplines,


### PR DESCRIPTION
I recently came across an article that shows that GitHub can automatically add a **"Cite this repository"** button when including a `CITATION.cff` file on the root of the project. The button will export an APA or **BibTeX citation automatically generated** from the file. (Further reading: [this article](https://github.blog/2021-08-19-enhanced-support-citations-github/) and [this other article](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files)).

As one of our goals is getting people to cite the original article (and we already have the respective BibTeX at the bottom of the README), I thought this could be interesting.

So I've been playing with it for a few hours now and I've successfully written a citation file that most closely generates the BibTeX specified on the README. You can see the button and generator in action in the merging branch, [citation](https://github.com/uva-trasgo/UVaFTLE/tree/citation).

The feature is somewhat limited and the BibTeX cannot be recreated perfectly (see further below). I've also had some issues with it while doing tests, and some requisites are... somewhat weird (the `cff` file can only describe `software` or `dataset` citations, and if you want it to generate an `article`, it has to be embedded as an additional citation inside the file, in the `preferred-citation` field). Nevertheless, I think the feature is kinda neat, and it might help the project get cited.

I leave the decision of including the file to the original authors.

For completeness, this is what the generated BibTeX looks like:
```BibTeX
@article{Carratala-Saez_UVaFTLE_Lagrangian_finite_2023,
author = {Carratalá-Sáez, Rocío and Torres, Yuri and Sierra-Pallares, José and López-Huguet, Sergio and Llanos, Diego R.},
doi = {10.1007/s11227-022-05017-x},
journal = {The Journal of Supercomputing},
month = {1},
title = {{UVaFTLE: Lagrangian finite time Lyapunov exponent extraction for fluid dynamic applications}},
year = {2023}
}
```
and this is the BibTeX citation we include in the README:

```BibTeX
@Article{Carratala2023:UVaFTLE
author = "Carratal{\'a}-S{\'a}ez, R., Torres, Y., Sierra-Pallares, J. et al.",
title="UVaFTLE: Lagrangian finite time Lyapunov exponent extraction for fluid dynamic applications",
journal="The Journal of Supercomputing",
year="2023",
issn="1573-0484",
doi="https://doi.org/10.1007/s11227-022-05017-x",
}   
```
(Notice how the automatically generated BibTeX can't write the accented letters properly, and the `issn` field is missing.)

I've added the author's ORCIDs to the `CITATION.cff` file, as every example I read had them written. (I think I didn't make any mistake with them.) The file can also include additional contact information, such as affiliation and e-mail; however I deliberately didn't add those since I don't know if the authors would want it added.