### PR TITLE
Fix author field syntax in BibTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ UVaFTLE , we would appreciate that you cite the following paper:
 
 ```BibTeX
 	@Article{Carratala2023:UvaFTLE,
-	author = "Carratal{\'a}-S{\'a}ez, R., Torres, Y., Sierra-Pallares, J. et al.",
+	author = "Carratal{\'a}-S{\'a}ez, Roc{\'i}o and Torres, Yuri and Sierra-Pallares, Jos{\'e} and others",
 	title="UVaFTLE: Lagrangian finite time Lyapunov exponent extraction for fluid dynamic applications",
 	journal="The Journal of Supercomputing",
 	year="2023",


### PR DESCRIPTION
The README's BibTeX citation uses an invalid syntax in the author field.

Authors should be separated by `and` (not a comma), and `et al.` is written in BibTeX with the keyword `others`. I have also added the complete given names of the authors, as I think LaTeX already is responsible for shortening them to just the initial (and only in some cases).

Here are the exact changes made:
```diff
-       author = "Carratal{\'a}-S{\'a}ez, R., Torres, Y., Sierra-Pallares, J. et al.",
+       author = "Carratal{\'a}-S{\'a}ez, Roc{\'i}o and Torres, Yuri and Sierra-Pallares, Jos{\'e} and others",
```